### PR TITLE
Update docs for webapp v2

### DIFF
--- a/docs/AdminControls.md
+++ b/docs/AdminControls.md
@@ -8,7 +8,7 @@ displayed_sidebar: webUiSidebar
 
 The admin page is where user's access is managed. An example page is show below:
 
-<img width="1294" alt="Admin" src="https://user-images.githubusercontent.com/46538575/219479669-dde8f89e-91ff-4848-a3bd-9931d6dac76b.png"/>
+<img width="1228" alt="Admin" src="https://user-images.githubusercontent.com/46538575/225719236-4a5681c2-e883-4acd-9302-ab2925f09eac.png"/>
 
 
 ### Access Levels

--- a/docs/DataExplorer.mdx
+++ b/docs/DataExplorer.mdx
@@ -8,7 +8,7 @@ import { FileSearchOutlined } from '@ant-design/icons';
 
 The <div className="button purple_button"><FileSearchOutlined /> **Data Explorer**</div> page offers an ANSI SQL interface to query tabular data generated from Ganymede _flows_.  
 
-<img width="1303" alt="Data_Explorer" src="https://user-images.githubusercontent.com/46538575/219486073-e4836b7c-5a3e-44bb-a99b-7aa299ce4681.png"/>
+<img width="1251" alt="DataExplorer" src="https://user-images.githubusercontent.com/46538575/225719033-5a93f896-2926-44b8-a871-7502d2cc8b34.png"/>
 
 - The Data Lake Tables pane contains a list of tables that exist in the current environment. 
   - There is a search bar to filter tables that contain the search string

--- a/docs/Files.mdx
+++ b/docs/Files.mdx
@@ -8,7 +8,7 @@ import { FolderOutlined } from '@ant-design/icons';
 
 The <div className="button purple_button"><FolderOutlined /> **Files**</div> page provides access to all of the data uploaded to Ganymede and all of your results from actions taken in the Flow Editor, organized by _flow_.
 
-<img width="1303" alt="FIles" src="https://user-images.githubusercontent.com/46538575/219479559-6ca50a88-490e-431d-9ebc-5eb10e87e6e7.png"/>
+<img width="1249" alt="Files" src="https://user-images.githubusercontent.com/46538575/225719095-f45c79ac-13c7-41ea-b81d-f0c23755e329.png"/>
 &nbsp;
 
 Input files can be found under the Uploaded Files section.   _Flow_ outputs can be found in the Results section of the Files page.
@@ -16,4 +16,4 @@ Input files can be found under the Uploaded Files section.   _Flow_ outputs can 
 To view other flows that have run the same file, click the "Details" button next to a file and a modal will open with that information. 
 To navigate to a particular run in the [Flow Runs page](FlowRuns.mdx), click on the Flow Run Id.
 
-<img width="1282" alt="Files_modal" src="https://user-images.githubusercontent.com/46538575/219479628-8b7762e1-ae23-45ed-ba69-d365479f0a02.png"/>
+<img width="1249" alt="Files2" src="https://user-images.githubusercontent.com/46538575/225719151-ac781bc9-de68-4074-8b37-141ce558bc42.png"/>

--- a/docs/FlowEditor.mdx
+++ b/docs/FlowEditor.mdx
@@ -14,7 +14,7 @@ import { NodeIndexOutlined,
 
 The <div className="button purple_button"><NodeIndexOutlined /> **Flow Editor**</div> page is the starting point for creating and modifying _flows_.  
 
-<img width="1124" alt="Flow_Editor" src="https://user-images.githubusercontent.com/46538575/219473714-af9da3da-eb25-43d8-aeea-2c7185f5a2df.png" />
+<img width="1124" alt="Quickstart" src="https://user-images.githubusercontent.com/46538575/225718050-e0ef0484-a46d-4476-a739-1d2ebdd811d1.png" />
 
 
 ## Header Bar
@@ -43,14 +43,14 @@ The header bar contains buttons for creating _flows_ and monitoring _flow_ runs.
 
 To create a new _flow_, click the <div className="button purple_button">**Manage <SettingOutlined />**</div> button in the upper right hand corner of the screen. Then click the <div className="button black_button">Add New Flow</div> button on the sidebar.  This action exposes a modal for naming and describing the _flow_.  
 
-<img width="1124" alt="Settings" src="https://user-images.githubusercontent.com/46538575/219474147-6d2c1582-af1e-4d97-afc7-e0e4cb901d33.png"/>
+<img width="1124" alt="Settings" src="https://user-images.githubusercontent.com/46538575/225718203-69bd40b2-6dec-4a3f-a186-40799a044da0.png"/>
 &nbsp;
 
 ### Loading and Saving Flows
 
 To load a _flow_, specify the _flow_ to load in the <div className="button purple_button">**Choose A Flow <DownOutlined />**</div> selection box.  Upon doing so, the primary pane displays the graphical structure of the _flow_.
 
-<img width="1335" alt="Choose_a_flow" src="https://user-images.githubusercontent.com/46538575/219477049-65a53948-6f96-4d3e-9841-a25686705a9d.png" />
+<img width="1241" alt="FlowEditor" src="https://user-images.githubusercontent.com/46538575/225718730-7e2dd267-e6ec-49c6-b77b-bd1183788022.png"/>
 &nbsp;
 
 After saving a _flow_, the entire environment (which contains all _flows_) is saved and deployed. When this save and deploy is taking place, users are temporarily restricted from running _flows_. A tooltip will be displayed to the user if they try to run a _flow_ during this time. Users can observe the status of environment updates on the [<div className="button purple_button"><NotificationOutlined /> **Notifications**</div>](Notifications.mdx) page.

--- a/docs/FlowRuns.mdx
+++ b/docs/FlowRuns.mdx
@@ -10,7 +10,7 @@ import { CheckCircleOutlined } from '@ant-design/icons';
 The <div className="button purple_button"><CheckCircleOutlined /> **Flow Runs**</div> page contains the current status of different _flow_ runs that have been executed.  To view historical runs for a given _flow_, select the _flow_ from the datalist in the header.
 To download or get more information on an input or output file, click on the file name to navigate to the [Files page](Files.mdx).
 
-<img width="1320" alt="Flow_runs" src="https://user-images.githubusercontent.com/46538575/219485822-2b1a2edb-825a-45b3-82ae-303dacfe0fae.png" />
+<img width="1288" alt="FlowRuns" src="https://user-images.githubusercontent.com/46538575/225718847-fc818fba-9e9e-41f9-ba72-2c4501fa73c6.png"/>
 
 ### Observing Flow Status
 

--- a/docs/Home.mdx
+++ b/docs/Home.mdx
@@ -18,7 +18,7 @@ import {
 
 The <div className="button purple_button"><HomeOutlined /> **Home**</div> page contains links to available _flows_ in an environment.  Clicking on any listed _flow_ brings you to the <div className="button purple_button"><HomeOutlined /> **Flow View**</div> page, from which the user can run the selected _flow_ and view historical runs.
 
-<img width="1417" alt="Screen Shot 2023-02-21 at 8 55 17 AM" src="https://user-images.githubusercontent.com/46538575/220379797-52ecb089-8240-4630-9afc-12dacaa59400.png" />
+<img width="1302" alt="Home" src="https://user-images.githubusercontent.com/46538575/225718404-f32ad40f-fa5b-488d-83ad-902ede21bf60.png"/>
 
 The search bar at the top filters available _flows_ by name.
 

--- a/docs/Notifications.mdx
+++ b/docs/Notifications.mdx
@@ -8,7 +8,7 @@ import { NotificationOutlined } from '@ant-design/icons';
 
 The <div className="button purple_button"><NotificationOutlined /> **Notifications**</div> page provides real time updates on the status of flow saves and runs. 
 
-<img width="1291" alt="Notifications" src="https://user-images.githubusercontent.com/46538575/219478385-1a24566b-28ba-4ea0-abb0-46eba41b798e.png"/>
+<img width="1251" alt="Notifications" src="https://user-images.githubusercontent.com/46538575/225718938-816b2bd0-90ff-43e1-9b64-5cf46ce76250.png"/>
 <br />
 <br />
 

--- a/docs/Quickstart.mdx
+++ b/docs/Quickstart.mdx
@@ -35,13 +35,13 @@ The <div className="button gray_button"><UserOutlined /> Sign In</div> button sh
 
 Click on the <div className="button purple_button"><NodeIndexOutlined /> **Flow Editor**</div> button in the sidebar.
 
-<img width="1124" alt="Flow_Editor" src="https://user-images.githubusercontent.com/46538575/219473714-af9da3da-eb25-43d8-aeea-2c7185f5a2df.png" />
+<img width="1124" alt="Quickstart" src="https://user-images.githubusercontent.com/46538575/225718050-e0ef0484-a46d-4476-a739-1d2ebdd811d1.png" />
 
 ### Step 3: Create a new flow
 
 Click on the <div className="button purple_button">**Manage <SettingOutlined />**</div> button in the upper right-hand corner of the header bar and select <div className="button black_button">Add New Flow</div> from the right sidebar.
 
-<img width="1124" alt="Settings" src="https://user-images.githubusercontent.com/46538575/219474147-6d2c1582-af1e-4d97-afc7-e0e4cb901d33.png"/>
+<img width="1124" alt="Settings" src="https://user-images.githubusercontent.com/46538575/225718203-69bd40b2-6dec-4a3f-a186-40799a044da0.png"/>
 &nbsp;
 
 


### PR DESCRIPTION
The current images in our docs have the new webapp design without the updates to colors and font. This PR includes images of the latest.

<img width="1228" alt="Admin" src="https://user-images.githubusercontent.com/46538575/225719500-cd19cc42-fc4e-416d-a17a-5211a1a18f46.png">
<img width="1249" alt="Files2" src="https://user-images.githubusercontent.com/46538575/225719503-1950b2c4-5675-406e-b6ac-ac2c1ce0287d.png">
<img width="1249" alt="Files" src="https://user-images.githubusercontent.com/46538575/225719504-62309856-bbad-413d-839b-5b560dcabb99.png">
<img width="1251" alt="DataExplorer" src="https://user-images.githubusercontent.com/46538575/225719506-daff5f40-debe-4f0a-9ad1-8784e00e1fcd.png">
<img width="1251" alt="Notifications" src="https://user-images.githubusercontent.com/46538575/225719508-429ca87b-1fad-45bc-b7d3-a06e554b3fed.png">
<img width="1288" alt="FlowRuns" src="https://user-images.githubusercontent.com/46538575/225719511-96ca695e-fb2e-4002-8045-3934adf53831.png">
<img width="1241" alt="FlowEditor" src="https://user-images.githubusercontent.com/46538575/225719512-207cada4-0ac4-4dea-ae78-4d8c48cbe922.png">
<img width="1302" alt="Home" src="https://user-images.githubusercontent.com/46538575/225719515-5133fac3-aad0-4a06-bb40-28e4e3a4887d.png">
<img width="1302" alt="Settings" src="https://user-images.githubusercontent.com/46538575/225719516-be5f8b7b-4594-455e-9048-045a5b474e78.png">
<img width="1302" alt="Quickstart" src="https://user-images.githubusercontent.com/46538575/225719517-5e0a8cd1-d763-48f2-8c24-e1925d8a1fe1.png">
