### PR TITLE
Add instructions for connecting to S3

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -75,7 +75,7 @@ recency
 AWS
 GCP
 CORS
-
+IAM
 
 ApiOutlined
 AppstoreOutlined

--- a/docs/app/admin/AdminControls.mdx
+++ b/docs/app/admin/AdminControls.mdx
@@ -77,40 +77,37 @@ The Integration panel contains details about the Ganymede environment, which can
 In order to allow Ganymede Flows to read and write to an S3 bucket, follow the steps below for each Ganymede environment that needs access to the bucket:
 
 1. Identify which S3 buckets you would like to connect to Ganymede
-
 1. Create a Policy that allows the desired access to the bucket(s), replacing `my-bucket` with the name of the bucket(s) you would like to connect to.
-Example:
-```
-  {
-      "Version": "2012-10-17",
-      "Statement": [
-          {
-              "Sid": "ListObjectsInBucket",
-              "Effect": "Allow",
-              "Action": [
-                  "s3:ListBucket"
-              ],
-              "Resource": [
-                  "arn:aws:s3:::my-bucket"
-              ]
-          },
-          {
-              "Sid": "AllObjectActions",
-              "Effect": "Allow",
-              "Action": "s3:*Object",
-              "Resource": [
-                  "arn:aws:s3:::my-bucket/*"
-              ]
-          }
-      ]
-  }
-```
-
+    Example:
+    ```
+      {
+          "Version": "2012-10-17",
+          "Statement": [
+              {
+                  "Sid": "ListObjectsInBucket",
+                  "Effect": "Allow",
+                  "Action": [
+                      "s3:ListBucket"
+                  ],
+                  "Resource": [
+                      "arn:aws:s3:::my-bucket"
+                  ]
+              },
+              {
+                  "Sid": "AllObjectActions",
+                  "Effect": "Allow",
+                  "Action": "s3:*Object",
+                  "Resource": [
+                      "arn:aws:s3:::my-bucket/*"
+                  ]
+              }
+          ]
+      }
+    ```
 1. Record the identity number of the Ganymede Environment
   - Navigate to the Environment Settings page
   - Select the Integration tab
   - Record the number in the `accounts.google.com:aud` field
-
 1. Create the Role in AWS
   - In the IAM console, select Roles > Create Role
   - Select 'Web Identity'
@@ -121,7 +118,6 @@ Example:
   - Press Next 
   - Name the role something like 'ganymede-storage-access'
   - Press Create Role
-
 
 ### Environment Detection in the SDK
 

--- a/docs/app/admin/AdminControls.mdx
+++ b/docs/app/admin/AdminControls.mdx
@@ -69,7 +69,59 @@ The Integration panel contains details about the Ganymede environment, which can
 - **Flow Runtime IP address**: IP address for workflow orchestration
 - **Notebook Service Account Email**: Service account for notebooks
 - **Flow Runtime Service Account Email**: Service account for workflow orchestration
-- **AWS Role JSON**: Role configuration for AWS Policy, to establish connectivity between Ganymede and Ganymede cloud
+- **AWS Role JSON**: Role configuration for AWS Policy, to establish connectivity between AWS and Ganymede cloud
+
+
+#### Connecting to an S3 Bucket
+
+In order to allow Ganymede Flows to read and write to an S3 bucket, follow the steps below for each Ganymede environment that needs access to the bucket:
+
+1. Identify which S3 buckets you would like to connect to Ganymede
+
+1. Create a Policy that allows the desired access to the bucket(s), replacing `my-bucket` with the name of the bucket(s) you would like to connect to.
+Example:
+```
+  {
+      "Version": "2012-10-17",
+      "Statement": [
+          {
+              "Sid": "ListObjectsInBucket",
+              "Effect": "Allow",
+              "Action": [
+                  "s3:ListBucket"
+              ],
+              "Resource": [
+                  "arn:aws:s3:::my-bucket"
+              ]
+          },
+          {
+              "Sid": "AllObjectActions",
+              "Effect": "Allow",
+              "Action": "s3:*Object",
+              "Resource": [
+                  "arn:aws:s3:::my-bucket/*"
+              ]
+          }
+      ]
+  }
+```
+
+1. Record the identity number of the Ganymede Environment
+  - Navigate to the Environment Settings page
+  - Select the Integration tab
+  - Record the number in the `accounts.google.com:aud` field
+
+1. Create the Role in AWS
+  - In the IAM console, select Roles > Create Role
+  - Select 'Web Identity'
+  - Select 'Google' as the Identity Provider
+  - Enter the identity number from above as the audience
+  - Press Next
+  - Select the Policy you created above as the permissions for the Role
+  - Press Next 
+  - Name the role something like 'ganymede-storage-access'
+  - Press Create Role
+
 
 ### Environment Detection in the SDK
 

--- a/docs/app/admin/AdminControls.mdx
+++ b/docs/app/admin/AdminControls.mdx
@@ -77,7 +77,7 @@ The Integration panel contains details about the Ganymede environment, which can
 In order to allow Ganymede Flows to read and write to an S3 bucket, follow the steps below for each Ganymede environment that needs access to the bucket:
 
 1. Identify which S3 buckets you would like to connect to Ganymede
-1. Create a Policy that allows the desired access to the bucket(s), replacing `my-bucket` with the name of the bucket(s) you would like to connect to.
+2. Create a Policy that allows the desired access to the bucket(s), replacing `my-bucket` with the name of the bucket(s) you would like to connect to.
     Example:
     ```
       {
@@ -104,11 +104,11 @@ In order to allow Ganymede Flows to read and write to an S3 bucket, follow the s
           ]
       }
     ```
-1. Record the identity number of the Ganymede Environment
+3. Record the identity number of the Ganymede Environment
   - Navigate to the Environment Settings page
   - Select the Integration tab
   - Record the number in the `accounts.google.com:aud` field
-1. Create the Role in AWS
+4. Create the Role in AWS
   - In the IAM console, select Roles > Create Role
   - Select 'Web Identity'
   - Select 'Google' as the Identity Provider
@@ -118,7 +118,7 @@ In order to allow Ganymede Flows to read and write to an S3 bucket, follow the s
   - Press Next 
   - Name the role something like 'ganymede-storage-access'
   - Press Create Role
-1. Add the Role ARN as an [environment secret in the Ganymede environment](#environment-secrets) named _aws_s3_role_arn_.
+5. Add the Role ARN as an [environment secret in the Ganymede environment](#environment-secrets) named _aws_s3_role_arn_.
 
 ### Environment Detection in the SDK
 

--- a/docs/app/admin/AdminControls.mdx
+++ b/docs/app/admin/AdminControls.mdx
@@ -118,6 +118,7 @@ In order to allow Ganymede Flows to read and write to an S3 bucket, follow the s
   - Press Next 
   - Name the role something like 'ganymede-storage-access'
   - Press Create Role
+1. Add the Role ARN as an [environment secret in the Ganymede environment](#environment-secrets) named _aws_s3_role_arn_.
 
 ### Environment Detection in the SDK
 


### PR DESCRIPTION
Description of Change
---
Add instructions for connecting an S3 bucket and a Ganymede environment

Reason
---
This is now self-service from the Integrations tab.

