### PR TITLE
move ganymedeexception to sdk

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -399,3 +399,6 @@ Cytiva
 searchability
 SuggestedTags
 Palantir
+GanymedeException
+FlowView
+useBaseURL

--- a/docs/app/flows/FlowView.mdx
+++ b/docs/app/flows/FlowView.mdx
@@ -119,7 +119,7 @@ Logs for each flow step can be accessed by clicking on the corresponding colored
 
 ### Error Attribution
 
-Developers using the platform can specify error types and messages associated with failed nodes. These are displayed on the status tag in the Run History table. Below is an example code snippet that would be placed within a node to raise an error:
+Developers using the platform can specify error types and messages associated with failed nodes using the GanymedeException class. These are displayed on the status tag in the Run History table. Below is an example code snippet that would be placed within a node to raise an error:
 
 ```python
 from ganymede_sdk.flow_runtime import GanymedeException
@@ -128,8 +128,4 @@ from ganymede_sdk.flow_runtime import GanymedeException
 raise GanymedeException(message=”Peaks not detected in results”, exception_type=”Function”)
 ```
 
-#### Categories of Errors
-
-- **Validation**: Schema validation errors. An example use case would be a Pandas DataFrame failing to validate against a Pandera schema.
-- **Connection**: Errors related to connecting to external services. Check for errors related to authentication, service availability, and access methods.
-- **Function**: Errors related to function logic. For example, a failed function call to a Python package would fall under this category.
+More detail on error types can be found in the [GanymedeException section of the Ganymede SDK documentation](../../sdk/DataValidation#class-ganymedeexception).

--- a/docs/sdk/DataValidation.mdx
+++ b/docs/sdk/DataValidation.mdx
@@ -100,12 +100,29 @@ query_sql = 'SELECT * FROM tbl WHERE flow_run_id = "{{flow_run_id}}";'
 result = g.retrieve_sql(query_sql)
 ```
 
+## `class` GanymedeException
+
+The **GanymedeException** class is a custom exception class that can be used to raise exceptions to attribute error type.
+
+```python
+from ganymede_sdk.flow_runtime import GanymedeException
+
+# available exception types are: Validation, Connection, Function
+raise GanymedeException('Only 1 replicate detected in sample; expected 3.', exception_type="Validation")
+```
+
+### Error Types
+
+- **Validation**: Schema validation errors. An example use case would be a Pandas DataFrame failing to validate against a Pandera schema.
+- **Connection**: Errors related to connecting to external services. Check for errors related to authentication, service availability, and access methods.
+- **Function**: Errors related to function logic. For example, a failed function call to a Python package would fall under this category.
+
 ## `function` compare_df_to_table
 
 *compare_df_to_table* allows users to compare the columns and schema on a Pandas DataFrame to a corresponding table in the Ganymede database.
 The function returns differences in column names and data types between the DataFrame and the table, and can be used to validate that the DataFrame matches the table schema before writing the DataFrame to the table.
 
-###  Parameters
+### Parameters
 - **ganymede_context** : `GanymedeContext`
     - Ganymede context to get run attributes
 - **df** : `pd.DataFrame`


### PR DESCRIPTION
Reason
---
Make GanymedeException easier to find; previously wasn't being crawled for some reason since the word "GanymedeException" wasn't featured prominently enough.
