### PR TITLE
fix typing for MultiFileParam definition

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -431,3 +431,4 @@ AgentToS
 BucketConfig
 prepending
 FullAccess
+ObservedFile

--- a/docs/sdk/markdowns/AgentSDK.mdx
+++ b/docs/sdk/markdowns/AgentSDK.mdx
@@ -54,7 +54,7 @@ FileParam specifies files to be uploaded to Ganymede Cloud and their correspondi
 
 MultiFileParam is used for submitting multiple files to a single node. It includes the following parameters:
 
-- _param_ **files**: str - Alternative method for specifying file contents, where the key is the filename and the value is the file body.
+- _param_ **files**: list[ObservedFile] - Alternative method for specifying file contents, where the key is the filename and the value is the file body.
 - _param_ **content_type**: str - Content type of file, e.g. "text/plain".  If not specified, the content type of the first file in the files dict will be used.
 - _param_ **param**: str - Name of parameter to be used in flow, e.g. `node_name`.`parameter_field_name`
 - _param_ **parent_dir**: str - Path within Agent watch directory that contains file.  For example. if C:/Users/username/watch_dir/ is being watched and C:/Users/username/watch_dir/abc/def/my_file.txt is found, then parent_dir would be "abc/def"

--- a/docs/sdk/markdowns/AgentSDK.mdx
+++ b/docs/sdk/markdowns/AgentSDK.mdx
@@ -54,7 +54,7 @@ FileParam specifies files to be uploaded to Ganymede Cloud and their correspondi
 
 MultiFileParam is used for submitting multiple files to a single node. It includes the following parameters:
 
-- _param_ **files**: list[ObservedFile] - Alternative method for specifying file contents, where the key is the filename and the value is the file body.
+- _param_ **files**: dict[str, bytes | str] | list[ObservedFile] - Alternative method for specifying file contents, where the key is the filename and the value is the file body.
 - _param_ **content_type**: str - Content type of file, e.g. "text/plain".  If not specified, the content type of the first file in the files dict will be used.
 - _param_ **param**: str - Name of parameter to be used in flow, e.g. `node_name`.`parameter_field_name`
 - _param_ **parent_dir**: str - Path within Agent watch directory that contains file.  For example. if C:/Users/username/watch_dir/ is being watched and C:/Users/username/watch_dir/abc/def/my_file.txt is found, then parent_dir would be "abc/def"


### PR DESCRIPTION

Description of Change
---

fixing typing of 'files' param of MultiFileParam from str -> dict[str, bytes | str] | list[ObservedFile]

https://github.com/Ganymede-Bio/remote-agent/blob/41870190fc52f730f2d3f37df33c5d37231c0c8f/agent/pipeline.py#L403C17-L403C29

Reason
---
documentation was previously incorrect

