### PR TITLE
Update API docs spec

### DIFF
--- a/scripts/prepare-api-spec.js
+++ b/scripts/prepare-api-spec.js
@@ -11,8 +11,8 @@ const path = require('path');
 const yaml = require('js-yaml');
 
 const SPEC_PATH = path.join(__dirname, '..', 'static', 'openapi.yaml');
-const FILTERED_GROUPS = ['Secrets'];
-const UNWANTED_TAGS = ['PublicApi', 'ganymede', 'AppsSync'];
+const FILTERED_GROUPS = ['Secrets', 'AppsSync'];
+const UNWANTED_TAGS = ['PublicApi', 'ganymede'];
 
 console.log('🔧 Preparing OpenAPI spec for Scalar...');
 

--- a/static/ganymede-api.postman_collection.json
+++ b/static/ganymede-api.postman_collection.json
@@ -12975,6 +12975,550 @@
           "protocolProfileBehavior": {
             "disableBodyPruning": true
           }
+        },
+        {
+          "id": "69750c55-fe41-42eb-8379-ea95b9279c51",
+          "name": "updateInstrument",
+          "request": {
+            "name": "updateInstrument",
+            "description": {
+              "content": "Update the connector connections associated with an existing Instrument. Supply the connector connection Ids to add and/or remove. Other Instrument fields cannot be modified through this endpoint.",
+              "type": "text/plain"
+            },
+            "url": {
+              "path": [
+                "v1",
+                "environment",
+                ":environment",
+                "instruments",
+                ":id"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": [
+                {
+                  "disabled": false,
+                  "type": "any",
+                  "value": "<string>",
+                  "key": "environment",
+                  "description": "(Required) "
+                },
+                {
+                  "disabled": false,
+                  "type": "any",
+                  "value": "<number>",
+                  "key": "id",
+                  "description": "(Required) "
+                },
+                {
+                  "description": {
+                    "content": "",
+                    "type": "text/plain"
+                  },
+                  "type": "any",
+                  "value": "{{host}}",
+                  "key": "host"
+                }
+              ]
+            },
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "method": "PATCH",
+            "auth": {
+              "type": "apikey",
+              "apikey": [
+                {
+                  "key": "key",
+                  "value": "api-key"
+                },
+                {
+                  "key": "value",
+                  "value": "{{apiKey}}"
+                },
+                {
+                  "key": "in",
+                  "value": "header"
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"dry_run\": \"<boolean>\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "response": [
+            {
+              "id": "92cafa3e-0701-4caa-9c3d-e5969d88ca58",
+              "name": "Instrument updated successfully",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "v1",
+                    "environment",
+                    ":environment",
+                    "instruments",
+                    ":id"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": [
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "<string>",
+                      "key": "environment",
+                      "description": "(Required) "
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "<number>",
+                      "key": "id",
+                      "description": "(Required) "
+                    },
+                    {
+                      "description": {
+                        "content": "",
+                        "type": "text/plain"
+                      },
+                      "type": "any",
+                      "value": "{{host}}",
+                      "key": "host"
+                    }
+                  ]
+                },
+                "header": [
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "api-key",
+                    "value": "<API Key>"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  }
+                ],
+                "method": "PATCH",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"dry_run\": \"<boolean>\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"id\": 1526.8111384770223,\n  \"createdAt\": \"string\",\n  \"name\": \"string\",\n  \"location\": \"string\",\n  \"serial\": \"string\",\n  \"metadata\": \"string\",\n  \"connectorConnectionIds\": [\n    \"string\",\n    \"string\"\n  ],\n  \"instrumentTypeId\": 4118.287462015469,\n  \"observationStartTime\": \"2015-10-26T08:07:53.910Z\",\n  \"timezone\": \"string\",\n  \"latitude\": -73.35153512359403,\n  \"longitude\": -130.7278687088813\n}",
+              "cookie": [],
+              "_postman_previewlanguage": "json"
+            },
+            {
+              "id": "1bac6a14-89d4-4614-8271-f4ca21dd0d50",
+              "name": "Bad Request - Invalid input data",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "v1",
+                    "environment",
+                    ":environment",
+                    "instruments",
+                    ":id"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": [
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "<string>",
+                      "key": "environment",
+                      "description": "(Required) "
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "<number>",
+                      "key": "id",
+                      "description": "(Required) "
+                    },
+                    {
+                      "description": {
+                        "content": "",
+                        "type": "text/plain"
+                      },
+                      "type": "any",
+                      "value": "{{host}}",
+                      "key": "host"
+                    }
+                  ]
+                },
+                "header": [
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "api-key",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "PATCH",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"dry_run\": \"<boolean>\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "status": "Bad Request",
+              "code": 400,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            },
+            {
+              "id": "f8c10704-78da-4526-964c-b1843679ba7d",
+              "name": "Instrument not found",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "v1",
+                    "environment",
+                    ":environment",
+                    "instruments",
+                    ":id"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": [
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "<string>",
+                      "key": "environment",
+                      "description": "(Required) "
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "<number>",
+                      "key": "id",
+                      "description": "(Required) "
+                    },
+                    {
+                      "description": {
+                        "content": "",
+                        "type": "text/plain"
+                      },
+                      "type": "any",
+                      "value": "{{host}}",
+                      "key": "host"
+                    }
+                  ]
+                },
+                "header": [
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "api-key",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "PATCH",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"dry_run\": \"<boolean>\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "status": "Not Found",
+              "code": 404,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": [],
+          "protocolProfileBehavior": {
+            "disableBodyPruning": true
+          }
+        },
+        {
+          "id": "92d73e30-7535-4760-b5c7-914b8879694e",
+          "name": "deleteInstrument",
+          "request": {
+            "name": "deleteInstrument",
+            "description": {
+              "content": "Delete an Instrument from an Environment.",
+              "type": "text/plain"
+            },
+            "url": {
+              "path": [
+                "v1",
+                "environment",
+                ":environment",
+                "instruments",
+                ":id"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [
+                {
+                  "disabled": false,
+                  "key": "dry_run",
+                  "value": "<boolean>"
+                }
+              ],
+              "variable": [
+                {
+                  "disabled": false,
+                  "type": "any",
+                  "value": "<string>",
+                  "key": "environment",
+                  "description": "(Required) "
+                },
+                {
+                  "disabled": false,
+                  "type": "any",
+                  "value": "<number>",
+                  "key": "id",
+                  "description": "(Required) "
+                },
+                {
+                  "description": {
+                    "content": "",
+                    "type": "text/plain"
+                  },
+                  "type": "any",
+                  "value": "{{host}}",
+                  "key": "host"
+                }
+              ]
+            },
+            "method": "DELETE",
+            "auth": {
+              "type": "apikey",
+              "apikey": [
+                {
+                  "key": "key",
+                  "value": "api-key"
+                },
+                {
+                  "key": "value",
+                  "value": "{{apiKey}}"
+                },
+                {
+                  "key": "in",
+                  "value": "header"
+                }
+              ]
+            }
+          },
+          "response": [
+            {
+              "id": "c858d212-c0bb-409e-9a4d-154a68ed8482",
+              "name": "Instrument deleted successfully",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "v1",
+                    "environment",
+                    ":environment",
+                    "instruments",
+                    ":id"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [
+                    {
+                      "key": "dry_run",
+                      "value": "<boolean>"
+                    }
+                  ],
+                  "variable": [
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "<string>",
+                      "key": "environment",
+                      "description": "(Required) "
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "<number>",
+                      "key": "id",
+                      "description": "(Required) "
+                    },
+                    {
+                      "description": {
+                        "content": "",
+                        "type": "text/plain"
+                      },
+                      "type": "any",
+                      "value": "{{host}}",
+                      "key": "host"
+                    }
+                  ]
+                },
+                "header": [
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "api-key",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "DELETE",
+                "body": {}
+              },
+              "status": "No Content",
+              "code": 204,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            },
+            {
+              "id": "a31ac99b-d19f-44e1-af7f-7cbf0aa10fa6",
+              "name": "Instrument not found",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "v1",
+                    "environment",
+                    ":environment",
+                    "instruments",
+                    ":id"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [
+                    {
+                      "key": "dry_run",
+                      "value": "<boolean>"
+                    }
+                  ],
+                  "variable": [
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "<string>",
+                      "key": "environment",
+                      "description": "(Required) "
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "<number>",
+                      "key": "id",
+                      "description": "(Required) "
+                    },
+                    {
+                      "description": {
+                        "content": "",
+                        "type": "text/plain"
+                      },
+                      "type": "any",
+                      "value": "{{host}}",
+                      "key": "host"
+                    }
+                  ]
+                },
+                "header": [
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "api-key",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "DELETE",
+                "body": {}
+              },
+              "status": "Not Found",
+              "code": 404,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": [],
+          "protocolProfileBehavior": {
+            "disableBodyPruning": true
+          }
         }
       ],
       "event": []

--- a/static/openapi.yaml
+++ b/static/openapi.yaml
@@ -2312,6 +2312,73 @@ paths:
       summary: getInstrument
       tags:
         - Instruments
+    patch:
+      description: Update the connector connections associated with an existing Instrument. Supply the connector connection Ids to add and/or remove. Other Instrument fields cannot be modified through this endpoint.
+      operationId: updateInstrument
+      parameters:
+        - name: environment
+          required: true
+          in: path
+          schema:
+            type: string
+        - name: id
+          required: true
+          in: path
+          schema:
+            type: number
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateInstrumentBody'
+      responses:
+        '200':
+          description: Instrument updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InstrumentDTO'
+        '400':
+          description: Bad Request - Invalid input data
+        '404':
+          description: Instrument not found
+      security:
+        - api-key: []
+        - BearerAuth: []
+      summary: updateInstrument
+      tags:
+        - Instruments
+    delete:
+      description: Delete an Instrument from an Environment.
+      operationId: deleteInstrument
+      parameters:
+        - name: environment
+          required: true
+          in: path
+          schema:
+            type: string
+        - name: id
+          required: true
+          in: path
+          schema:
+            type: number
+        - name: dry_run
+          required: false
+          in: query
+          schema:
+            type: boolean
+      responses:
+        '204':
+          description: Instrument deleted successfully
+        '404':
+          description: Instrument not found
+      security:
+        - api-key: []
+        - BearerAuth: []
+      summary: deleteInstrument
+      tags:
+        - Instruments
   /v1/environment/{environment}/modularAnalysis:
     get:
       description: Get all [Modular Analysis](https://docs.ganymede.bio/app/ma/ModularAnalysisOverview) apps for an Environment.
@@ -5669,6 +5736,24 @@ components:
         - id
         - createdAt
         - name
+    UpdateInstrumentBody:
+      type: object
+      properties:
+        addConnectionIds:
+          default: []
+          description: Connector connection Ids to associate with this instrument. Each id must reference an existing connector connection.
+          type: array
+          items:
+            type: string
+        removeConnectionIds:
+          default: []
+          description: Connector connection Ids to disassociate from this instrument. Ids not currently associated with the instrument are ignored.
+          type: array
+          items:
+            type: string
+        dry_run:
+          type: boolean
+          description: If true, perform a dry run without actually updating the instrument
     ModularAnalysisDTO:
       type: object
       properties:


### PR DESCRIPTION
## Summary
- Add the Instrument update/delete endpoint definitions to the API docs spec
- Add the matching Instrument requests to the bundled Postman collection
- Treat AppsSync as a filtered OpenAPI group so internal AppsSync endpoints are not published to the docs page in future generated specs
- Pin the api-server submodule to the merge commit that introduced the Instrument endpoints

## Verification
- Confirmed static/openapi.yaml does not include /apps/sync or the unrelated Modular Analysis version/diff paths
- yarn build

Note: swagger-cli validation still reports `Token "LegacyFWFlowConnectorConfig" does not exist`; this also occurs against the previous HEAD spec, so it is not introduced by this update.